### PR TITLE
add wifi.on_connect and wifi.on_disconnect triggers

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -32,6 +32,8 @@ from esphome.const import (
     CONF_KEY,
     CONF_USERNAME,
     CONF_EAP,
+    CONF_ON_CONNECT,
+    CONF_ON_DISCONNECT,
 )
 from esphome.core import CORE, HexInt, coroutine_with_priority
 from esphome.components.esp32 import add_idf_sdkconfig_option
@@ -284,6 +286,8 @@ CONFIG_SCHEMA = cv.All(
                 "This option has been removed. Please use the [disabled] option under the "
                 "new mdns component instead."
             ),
+            cv.Optional(CONF_ON_CONNECT): automation.validate_automation(),
+            cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(),
         }
     ),
     _validate,
@@ -392,8 +396,15 @@ async def to_code(config):
 
     cg.add_define("USE_WIFI")
 
-    # Register at end for OTA safe mode
+    # Register before OTA safe mode check
     await cg.register_component(var, config)
+
+    for conf in config.get(CONF_ON_CONNECT, []):
+        # OTA safe mode check invoked through here
+        await automation.build_automation(var.get_connect_trigger(), [], conf)
+
+    for conf in config.get(CONF_ON_DISCONNECT, []):
+        await automation.build_automation(var.get_disconnect_trigger(), [], conf)
 
 
 @automation.register_condition("wifi.connected", WiFiConnectedCondition, cv.Schema({}))

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -161,7 +161,9 @@ void WiFiComponent::loop() {
   }
 }
 
-WiFiComponent::WiFiComponent() { global_wifi_component = this; }
+WiFiComponent::WiFiComponent() : connect_trigger_(new Trigger<>()), disconnect_trigger_(new Trigger<>()) {
+  global_wifi_component = this;
+}
 
 bool WiFiComponent::has_ap() const { return this->has_ap_; }
 bool WiFiComponent::has_sta() const { return !this->sta_.empty(); }
@@ -628,6 +630,9 @@ bool WiFiComponent::is_esp32_improv_active_() {
   return false;
 #endif
 }
+
+Trigger<> *WiFiComponent::get_connect_trigger() const { return this->connect_trigger_; }
+Trigger<> *WiFiComponent::get_disconnect_trigger() const { return this->disconnect_trigger_; }
 
 void WiFiAP::set_ssid(const std::string &ssid) { this->ssid_ = ssid; }
 void WiFiAP::set_bssid(bssid_t bssid) { this->bssid_ = bssid; }

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -265,6 +265,9 @@ class WiFiComponent : public Component {
 
   int8_t wifi_rssi();
 
+  Trigger<> *get_connect_trigger() const;
+  Trigger<> *get_disconnect_trigger() const;
+
  protected:
   static std::string format_mac_addr(const uint8_t mac[6]);
   void setup_ap_config_();
@@ -336,6 +339,9 @@ class WiFiComponent : public Component {
   bool btm_{false};
   bool rrm_{false};
 #endif
+
+  Trigger<> *connect_trigger_;
+  Trigger<> *disconnect_trigger_;
 };
 
 extern WiFiComponent *global_wifi_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -477,6 +477,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       ESP_LOGV(TAG, "Event: Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
                format_mac_addr(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
 
+      this->connect_trigger_->trigger();
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_DISCONNECTED: {
@@ -507,6 +508,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       }
 
       s_sta_connecting = false;
+      this->disconnect_trigger_->trigger();
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_AUTHMODE_CHANGE: {

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -468,6 +468,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       ESP_LOGV(TAG, "Event: Connected ssid='%s' bssid=%s channel=%u", buf, format_mac_addr(it.bssid).c_str(),
                it.channel);
       s_sta_connected = true;
+      global_wifi_component->connect_trigger_->trigger();
       break;
     }
     case EVENT_STAMODE_DISCONNECTED: {
@@ -485,6 +486,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       }
       s_sta_connected = false;
       s_sta_connecting = false;
+      global_wifi_component->disconnect_trigger_->trigger();
       break;
     }
     case EVENT_STAMODE_AUTHMODE_CHANGE: {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -617,6 +617,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     ESP_LOGV(TAG, "Event: Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
              format_mac_addr(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
     s_sta_connected = true;
+    this->connect_trigger_->trigger();
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_DISCONNECTED) {
     const auto &it = data->data.sta_disconnected;
@@ -636,6 +637,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     s_sta_connected = false;
     s_sta_connecting = false;
     error_from_callback_ = true;
+    this->disconnect_trigger_->trigger();
 
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_STA_GOT_IP) {
     const auto &it = data->data.ip_got_ip;

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -80,6 +80,10 @@ wifi:
   domain: .local
   reboot_timeout: 120s
   power_save_mode: light
+  on_connect:
+    - light.turn_on: ${roomname}_lights
+  on_disconnect:
+    - light.turn_off: ${roomname}_lights
 
 mdns:
   disabled: false


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
